### PR TITLE
v0.2.1: ORCH_VERSION directive and optional PUBLISH host address

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "orch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orch"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ ORCH_ARG_postgres_port=9999 orch parse Orchfile
 ## Example Orchfile
 
 ```
+ORCH_VERSION 0.2.1
+
 ARG postgres_port=5433
 ARG django_port=9090
 
@@ -91,7 +93,7 @@ orch parse Orchfile
 
 ```json
 {
-  "version": "0.1.0",
+  "version": "0.2.1",
   "args": {
     "postgres_port": "5433",
     "django_port": "9090"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,5 +1,6 @@
 # Orchfile Specification
 
+**Version**: 0.2.1  
 **Target**: Local, ephemeral, development, and staging environments  
 **Not for**: Production deployments at scale
 
@@ -79,6 +80,16 @@ Service dependencies defined by `REQUIRES` and `AFTER` MUST form a directed acyc
 ## Directives Reference
 
 ### Global Directives
+
+#### ORCH_VERSION
+
+Asserts the Orchfile spec version the file targets. Optional, but if present it must be the first directive and appear before any `SERVICE`. A version that the parser does not support is a parse error.
+
+```
+ORCH_VERSION 0.2.1
+```
+
+When omitted, the file is assumed to target the parser's current spec version. In multi-file composition, any file may declare it.
 
 #### ARG
 
@@ -166,14 +177,17 @@ CMD -g 'daemon off;'
 
 #### PUBLISH
 
-Map host port to container port.
+Map host port to container port, optionally bound to a specific host address.
 
 ```
 PUBLISH 5433:5432
 PUBLISH 8080:80
+PUBLISH 127.0.0.1:8080:80
 ```
 
-**Format**: `host_port:container_port`
+**Format**: `[address:]host_port:container_port`
+
+**Host address**: Optional. When given, the published port binds only to that address (e.g. `127.0.0.1`); when omitted, the platform default applies (typically all interfaces). IPv4, IPv6, and hostnames are accepted.
 
 **Multiple allowed**: Specify multiple PUBLISH directives for multiple port mappings.
 
@@ -676,7 +690,7 @@ SERVICE web
 #### Keyed Lists: Merge by Key
 
 - **ENV**: Merged by variable name (overlay wins on conflict)
-- **PUBLISH**: Merged by container port (overlay replaces host port for same container port)
+- **PUBLISH**: Merged by container port (overlay replaces host address and port for same container port)
 - **VOLUME**: Merged by destination path (overlay replaces source for same destination)
 
 ```

--- a/examples/demo.orch
+++ b/examples/demo.orch
@@ -1,5 +1,7 @@
 # Example Orchfile for a typical Django + Postgres + Redis stack
 
+ORCH_VERSION 0.2.1
+
 ARG postgres_port=5433
 ARG postgres_memory=4G
 ARG django_port=9090
@@ -20,7 +22,7 @@ SERVICE redis
 FROM redis:6.2.0-alpine
 MEMORY 1G
 CPUS 1
-PUBLISH 6380:6379
+PUBLISH 127.0.0.1:6380:6379
 RECREATE always
 HEALTHCHECK redis-cli -h localhost -p 6380 ping
 RESTART always

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -1,8 +1,9 @@
 orchfile    ::= ( line newline )*
-line        ::= blank | comment | arg | service_decl | directive
+line        ::= blank | comment | version | arg | service_decl | directive
 blank       ::= ws*
 comment     ::= ws* '#' any*
 
+version     ::= 'ORCH_VERSION' ws version_number
 arg         ::= 'ARG' ws identifier '=' value
 service_decl ::= 'SERVICE' ws service_name
 
@@ -29,7 +30,7 @@ mode_directive
 container_directive
             ::= 'ENTRYPOINT' ws command_string
               | 'CMD' ws command_string
-              | 'PUBLISH' ws port ':' port
+              | 'PUBLISH' ws ( host_address ':' )? port ':' port
               | 'VOLUME' ws volume_source ':' path
 
 /* Host-only */
@@ -120,6 +121,8 @@ percentage  ::= integer '%'
 number      ::= integer ( '.' digit+ )?
 integer     ::= digit+
 port        ::= digit+   /* 1-65535 */
+version_number ::= integer '.' integer '.' integer
+host_address ::= ( letter | digit | '.' | ':' )+   /* IPv4, IPv6, or hostname */
 
 letter      ::= [a-z]
 digit       ::= [0-9]

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -110,11 +110,11 @@ fn merge_service(base: &mut RawService, overlay: RawService) {
     // Keyed map: ENV (merge by var name)
     merge_keyed_map(&mut base.env, overlay.env);
 
-    // Keyed list: PUBLISH (merge by container port — second element)
-    merge_keyed_vec(&mut base.publish, overlay.publish, 1);
+    // Keyed list: PUBLISH (merge by container port — third element)
+    merge_keyed_vec(&mut base.publish, overlay.publish, |e| e.2.as_str());
 
     // Keyed list: VOLUME (merge by destination — second element)
-    merge_keyed_vec(&mut base.volumes, overlay.volumes, 1);
+    merge_keyed_vec(&mut base.volumes, overlay.volumes, |e| e.1.as_str());
 
     // Positional lists: append + dedup
     merge_positional(&mut base.requires, overlay.requires);
@@ -156,25 +156,22 @@ fn merge_keyed_map(base: &mut ClearableMap, overlay: ClearableMap) {
     }
 }
 
-/// Keyed vec merge (PUBLISH, VOLUME): merge by element at `key_index`.
-/// If cleared, discard base values first.
-fn merge_keyed_vec(
-    base: &mut ClearableVec<(String, String)>,
-    overlay: ClearableVec<(String, String)>,
-    key_index: usize,
-) {
+/// Keyed vec merge (PUBLISH, VOLUME): merge by the key produced by `key_of`.
+/// If cleared, discard base values first; otherwise overlay entries replace
+/// base entries with the same key, and new keys are appended.
+fn merge_keyed_vec<T, F>(base: &mut ClearableVec<T>, overlay: ClearableVec<T>, key_of: F)
+where
+    F: Fn(&T) -> &str,
+{
     if overlay.cleared {
         base.values.clear();
     }
 
     for entry in overlay.values {
-        let key = if key_index == 0 { &entry.0 } else { &entry.1 };
+        let key = key_of(&entry).to_string();
 
         // Find and replace existing entry with same key, or append
-        if let Some(existing) = base.values.iter_mut().find(|e| {
-            let existing_key = if key_index == 0 { &e.0 } else { &e.1 };
-            existing_key == key
-        }) {
+        if let Some(existing) = base.values.iter_mut().find(|e| key_of(e) == key) {
             *existing = entry;
         } else {
             base.values.push(entry);

--- a/src/merge/tests.rs
+++ b/src/merge/tests.rs
@@ -201,32 +201,32 @@ fn test_merge__publish_merge_by_container_port() {
     let mut s1 = svc_with_from("web", "nginx", 0);
     s1.publish
         .values
-        .push(("8080".to_string(), "80".to_string()));
+        .push(("".to_string(), "8080".to_string(), "80".to_string()));
     s1.publish
         .values
-        .push(("8443".to_string(), "443".to_string()));
+        .push(("".to_string(), "8443".to_string(), "443".to_string()));
 
     let mut s2 = raw_svc("web", 1);
     s2.publish
         .values
-        .push(("9090".to_string(), "80".to_string())); // override port 80
+        .push(("".to_string(), "9090".to_string(), "80".to_string())); // override port 80
     s2.publish
         .values
-        .push(("3000".to_string(), "3000".to_string())); // new
+        .push(("".to_string(), "3000".to_string(), "3000".to_string())); // new
 
     let result = merge(vec![raw_file(vec![], vec![s1]), raw_file(vec![], vec![s2])]);
     let pubs = &result.services[0].publish.values;
 
     assert_eq!(pubs.len(), 3);
     // Port 80: overridden host from 8080 to 9090
-    let p80 = pubs.iter().find(|(_, c)| c == "80").unwrap();
-    assert_eq!(p80.0, "9090");
+    let p80 = pubs.iter().find(|(_, _, c)| c == "80").unwrap();
+    assert_eq!(p80.1, "9090");
     // Port 443: unchanged
-    let p443 = pubs.iter().find(|(_, c)| c == "443").unwrap();
-    assert_eq!(p443.0, "8443");
+    let p443 = pubs.iter().find(|(_, _, c)| c == "443").unwrap();
+    assert_eq!(p443.1, "8443");
     // Port 3000: new
-    let p3000 = pubs.iter().find(|(_, c)| c == "3000").unwrap();
-    assert_eq!(p3000.0, "3000");
+    let p3000 = pubs.iter().find(|(_, _, c)| c == "3000").unwrap();
+    assert_eq!(p3000.1, "3000");
 }
 
 #[test]
@@ -234,20 +234,20 @@ fn test_merge__publish_clear_then_add() {
     let mut s1 = svc_with_from("web", "nginx", 0);
     s1.publish
         .values
-        .push(("8080".to_string(), "80".to_string()));
+        .push(("".to_string(), "8080".to_string(), "80".to_string()));
 
     let mut s2 = raw_svc("web", 1);
     s2.publish.cleared = true;
     s2.publish
         .values
-        .push(("9090".to_string(), "80".to_string()));
+        .push(("".to_string(), "9090".to_string(), "80".to_string()));
 
     let result = merge(vec![raw_file(vec![], vec![s1]), raw_file(vec![], vec![s2])]);
     let pubs = &result.services[0].publish.values;
 
     assert_eq!(pubs.len(), 1);
-    assert_eq!(pubs[0].0, "9090");
-    assert_eq!(pubs[0].1, "80");
+    assert_eq!(pubs[0].1, "9090");
+    assert_eq!(pubs[0].2, "80");
 }
 
 // ---------------------------------------------------------------------------
@@ -349,7 +349,7 @@ fn test_merge__switch_to_host_clears_container_directives() {
     s1.cmd = Some("nginx -g 'daemon off;'".to_string());
     s1.publish
         .values
-        .push(("8080".to_string(), "80".to_string()));
+        .push(("".to_string(), "8080".to_string(), "80".to_string()));
     s1.volumes
         .values
         .push(("./html".to_string(), "/usr/share/nginx/html".to_string()));
@@ -469,7 +469,9 @@ fn test_merge__single_file_identity() {
 fn test_merge__three_file_cascade() {
     let mut s1 = svc_with_from("web", "nginx:1.24", 0);
     s1.env.values.insert("MODE".to_string(), "prod".to_string());
-    s1.publish.values.push(("80".to_string(), "80".to_string()));
+    s1.publish
+        .values
+        .push(("".to_string(), "80".to_string(), "80".to_string()));
     s1.requires.values.push("db".to_string());
 
     let mut s2 = raw_svc("web", 1);
@@ -480,7 +482,7 @@ fn test_merge__three_file_cascade() {
         .insert("MODE".to_string(), "staging".to_string());
     s2.publish
         .values
-        .push(("8080".to_string(), "80".to_string())); // override host for port 80
+        .push(("".to_string(), "8080".to_string(), "80".to_string())); // override host for port 80
 
     let mut s3 = raw_svc("web", 2);
     s3.env
@@ -500,8 +502,8 @@ fn test_merge__three_file_cascade() {
     assert_eq!(svc.env.values.get("DEBUG").unwrap(), "true");
     // Port 80 host overridden to 8080
     assert_eq!(svc.publish.values.len(), 1);
-    assert_eq!(svc.publish.values[0].0, "8080");
-    assert_eq!(svc.publish.values[0].1, "80");
+    assert_eq!(svc.publish.values[0].1, "8080");
+    assert_eq!(svc.publish.values[0].2, "80");
     // Requires: db + cache (deduped)
     assert_eq!(svc.requires.values, &["db", "cache"]);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,6 +99,7 @@ pub fn parse_raw(input: &str, file_index: usize) -> Result<RawOrchFile, Vec<Orch
     let mut errors: Vec<OrchError> = Vec::new();
     let mut current_service: Option<RawService> = None;
     let mut seen_service_names: HashMap<String, usize> = HashMap::new();
+    let mut orch_version_line: Option<usize> = None;
 
     // Pass 1: collect ARG defaults (no override application — deferred to resolve)
     for (line_num_0, raw_line) in input.lines().enumerate() {
@@ -140,6 +141,49 @@ pub fn parse_raw(input: &str, file_index: usize) -> Result<RawOrchFile, Vec<Orch
         let (directive, value) = split_directive(line);
 
         if directive == "ARG" {
+            continue;
+        }
+
+        // ORCH_VERSION: file-global, must precede any SERVICE, asserts spec compatibility.
+        if directive == "ORCH_VERSION" {
+            if current_service.is_some() || !services.is_empty() {
+                errors.push(
+                    ParseError::new(line_num, "ORCH_VERSION must appear before any SERVICE").into(),
+                );
+                continue;
+            }
+            if let Some(prev) = orch_version_line {
+                errors.push(
+                    ParseError::new(
+                        line_num,
+                        format!("duplicate ORCH_VERSION directive (first defined at line {})", prev),
+                    )
+                    .into(),
+                );
+                continue;
+            }
+            orch_version_line = Some(line_num);
+            match value {
+                Some(v) if !v.is_empty() => {
+                    if v != SPEC_VERSION {
+                        errors.push(
+                            ParseError::new(
+                                line_num,
+                                format!(
+                                    "unsupported Orchfile version '{}' (this parser supports {})",
+                                    v, SPEC_VERSION
+                                ),
+                            )
+                            .into(),
+                        );
+                    }
+                }
+                _ => {
+                    errors.push(
+                        ParseError::new(line_num, "ORCH_VERSION requires a version value").into(),
+                    );
+                }
+            }
             continue;
         }
 
@@ -354,23 +398,25 @@ pub fn parse_raw(input: &str, file_index: usize) -> Result<RawOrchFile, Vec<Orch
                     .push(("PUBLISH".to_string(), line_num, file_index));
                 let val = require_raw_value(&raw_val, "PUBLISH", line_num, &mut errors);
                 if let Some(v) = val {
-                    // Validate format (has colon) but store raw strings
+                    // `[address:]host_port:container_port`. Last two groups are
+                    // the ports; rsplit keeps ':'-bearing addresses (IPv6) intact.
                     let parts: Vec<&str> = v.split(':').collect();
-                    if parts.len() != 2 {
+                    if parts.len() < 2 {
                         errors.push(
                             ParseError::new(
                                 line_num,
                                 format!(
-                                    "invalid PUBLISH format '{}', expected host_port:container_port",
+                                    "invalid PUBLISH format '{}', expected [address:]host_port:container_port",
                                     v
                                 ),
                             )
                             .into(),
                         );
                     } else {
-                        svc.publish
-                            .values
-                            .push((parts[0].to_string(), parts[1].to_string()));
+                        let container = parts[parts.len() - 1].to_string();
+                        let host_port = parts[parts.len() - 2].to_string();
+                        let address = parts[..parts.len() - 2].join(":");
+                        svc.publish.values.push((address, host_port, container));
                     }
                 }
             }

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -806,7 +806,7 @@ ONESHOT true
 fn test_json_serialization() {
     let orch = parse_ok("SERVICE db\nFROM postgres:15\nPUBLISH 5432:5432\n");
     let json = serde_json::to_string_pretty(&orch).unwrap();
-    assert!(json.contains("\"version\": \"0.2.0\""));
+    assert!(json.contains("\"version\": \"0.2.1\""));
     assert!(json.contains("\"name\": \"db\""));
     assert!(json.contains("\"mode\": \"container\""));
     assert!(json.contains("\"host\": 5432"));
@@ -1306,4 +1306,110 @@ SERVICE web
         "expected unknown directive error, got: {:?}",
         errors
     );
+}
+
+// =========================================================================
+// ORCH_VERSION directive
+// =========================================================================
+
+#[test]
+fn test_orch_version__matching_is_accepted() {
+    let input = format!(
+        "ORCH_VERSION {}\nSERVICE db\nFROM postgres:15\n",
+        orch::types::SPEC_VERSION
+    );
+    let orch = parse_ok(&input);
+    assert_eq!(orch.version, orch::types::SPEC_VERSION);
+}
+
+#[test]
+fn test_orch_version__mismatch_is_rejected() {
+    let errors = parse_err("ORCH_VERSION 9.9.9\nSERVICE db\nFROM img\n");
+    let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    assert!(msgs.iter().any(|m| m.contains("unsupported Orchfile version '9.9.9'")));
+}
+
+#[test]
+fn test_orch_version__must_precede_service() {
+    let input = format!(
+        "SERVICE db\nFROM img\nORCH_VERSION {}\n",
+        orch::types::SPEC_VERSION
+    );
+    let errors = parse_err(&input);
+    let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    assert!(msgs.iter().any(|m| m.contains("must appear before any SERVICE")));
+}
+
+#[test]
+fn test_orch_version__duplicate_is_rejected() {
+    let v = orch::types::SPEC_VERSION;
+    let input = format!("ORCH_VERSION {v}\nORCH_VERSION {v}\nSERVICE db\nFROM img\n");
+    let errors = parse_err(&input);
+    let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    assert!(msgs.iter().any(|m| m.contains("duplicate ORCH_VERSION")));
+}
+
+#[test]
+fn test_orch_version__requires_value() {
+    let errors = parse_err("ORCH_VERSION\nSERVICE db\nFROM img\n");
+    let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+    assert!(msgs.iter().any(|m| m.contains("ORCH_VERSION requires a version value")));
+}
+
+#[test]
+fn test_orch_version__absent_defaults_to_spec_version() {
+    let orch = parse_ok("SERVICE db\nFROM img\n");
+    assert_eq!(orch.version, orch::types::SPEC_VERSION);
+}
+
+// =========================================================================
+// PUBLISH optional host address
+// =========================================================================
+
+#[test]
+fn test_publish__no_address_yields_none() {
+    let orch = parse_ok("SERVICE x\nFROM img\nPUBLISH 8080:80\n");
+    let p = &orch.services[0].publish[0];
+    assert_eq!(p.address, None);
+    assert_eq!(p.host, 8080);
+    assert_eq!(p.container, 80);
+}
+
+#[test]
+fn test_publish__with_host_address() {
+    let orch = parse_ok("SERVICE x\nFROM img\nPUBLISH 127.0.0.1:8080:80\n");
+    let p = &orch.services[0].publish[0];
+    assert_eq!(p.address.as_deref(), Some("127.0.0.1"));
+    assert_eq!(p.host, 8080);
+    assert_eq!(p.container, 80);
+}
+
+#[test]
+fn test_publish__ipv6_host_address() {
+    let orch = parse_ok("SERVICE x\nFROM img\nPUBLISH ::1:8080:80\n");
+    let p = &orch.services[0].publish[0];
+    assert_eq!(p.address.as_deref(), Some("::1"));
+    assert_eq!(p.host, 8080);
+    assert_eq!(p.container, 80);
+}
+
+#[test]
+fn test_publish__address_expands_vars() {
+    let input = "ARG ip=127.0.0.1\nSERVICE x\nFROM img\nPUBLISH ${ip}:8080:80\n";
+    let orch = parse_ok(input);
+    assert_eq!(orch.services[0].publish[0].address.as_deref(), Some("127.0.0.1"));
+}
+
+#[test]
+fn test_publish__address_omitted_from_json_when_none() {
+    let orch = parse_ok("SERVICE x\nFROM img\nPUBLISH 8080:80\n");
+    let json = serde_json::to_string(&orch).unwrap();
+    assert!(!json.contains("address"));
+}
+
+#[test]
+fn test_publish__address_present_in_json() {
+    let orch = parse_ok("SERVICE x\nFROM img\nPUBLISH 127.0.0.1:8080:80\n");
+    let json = serde_json::to_string(&orch).unwrap();
+    assert!(json.contains("\"address\":\"127.0.0.1\""));
 }

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -45,7 +45,7 @@ pub fn resolve(
 
     // Step 7: C4 - DAG acyclicity
     let orch = OrchFile {
-        version: "0.2.0".to_string(),
+        version: SPEC_VERSION.to_string(),
         args,
         services,
     };
@@ -127,11 +127,21 @@ fn resolve_service(
 
     // Expand and parse PUBLISH
     let mut publish: Vec<PortMapping> = Vec::new();
-    for (host_raw, container_raw) in &raw.publish.values {
+    for (addr_raw, host_raw, container_raw) in &raw.publish.values {
+        let addr_str = expand_vars(addr_raw, args);
         let host_str = expand_vars(host_raw, args);
         let container_str = expand_vars(container_raw, args);
+        let address = if addr_str.is_empty() {
+            None
+        } else {
+            Some(addr_str)
+        };
         match (host_str.parse::<u16>(), container_str.parse::<u16>()) {
-            (Ok(host), Ok(container)) => publish.push(PortMapping { host, container }),
+            (Ok(host), Ok(container)) => publish.push(PortMapping {
+                address,
+                host,
+                container,
+            }),
             (Err(_), _) => {
                 errors.push(
                     ValidationError::new(

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// The Orchfile spec version this parser implements (mirrors the package version).
+pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum ServiceMode {
@@ -37,6 +40,9 @@ impl Default for RecreatePolicy {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PortMapping {
+    /// Optional host bind address (e.g. `127.0.0.1`). `None` binds all interfaces.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub address: Option<String>,
     pub host: u16,
     pub container: u16,
 }
@@ -201,7 +207,7 @@ pub struct OrchFile {
 impl OrchFile {
     pub fn new() -> Self {
         OrchFile {
-            version: "0.2.0".to_string(),
+            version: SPEC_VERSION.to_string(),
             args: HashMap::new(),
             services: Vec::new(),
         }
@@ -294,7 +300,7 @@ pub struct RawService {
     pub cmd: Option<String>,
 
     // Container-only keyed lists (key: container_port / destination)
-    pub publish: ClearableVec<(String, String)>, // (host_raw, container_raw)
+    pub publish: ClearableVec<(String, String, String)>, // (address_raw, host_port_raw, container_port_raw)
     pub volumes: ClearableVec<(String, String)>, // (source_raw, dest_raw)
 
     // Host-only scalars


### PR DESCRIPTION
## Summary
Releases **0.2.1**, clubbing three related changes.

### 1. `ORCH_VERSION` directive (new)
File-global directive asserting spec compatibility. Must appear before any `SERVICE`; optional (absence defaults to the parser's spec version). A declared version that doesn't match the parser's supported version is a parse error. Duplicates and missing values are also caught.

### 2. `PUBLISH` optional host address
Format is now `[address:]host_port:container_port` (like Docker's `ip:hostPort:containerPort`). `PortMapping` gains an optional `address` field, omitted from JSON when unset. Ports are split from the right so IPv6 addresses stay intact. Merge still keys by container port.

### 3. Version formalization
`SPEC_VERSION` now derives from `CARGO_PKG_VERSION`, making `Cargo.toml` the single source of truth (no more triplicated literals). Bumped to `0.2.1`; propagates to JSON output, the `ORCH_VERSION` check, and `OrchFile::new`.

## Docs
Updated `SPEC.md` (version header, new `ORCH_VERSION` section, PUBLISH section, merge note), `grammar.ebnf` (rules + `host_address`/`version_number` terminals), `README.md` (also fixed a stale `0.1.0` in the JSON sample), and `examples/demo.orch`.

## Tests
Added 12 tests (6 `ORCH_VERSION`, 6 PUBLISH address); updated merge tests for the new tuple shape. **152 passing**, builds clean.