### PR TITLE
v0.2.2: library API + spec/tool version decoupling (closes #4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "orch"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orch"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ORCH_ARG_postgres_port=9999 orch parse Orchfile
 ## Example Orchfile
 
 ```
-ORCH_VERSION 0.2.1
+ORCH_VERSION 1.0.0-rc
 
 ARG postgres_port=5433
 ARG django_port=9090
@@ -93,7 +93,7 @@ orch parse Orchfile
 
 ```json
 {
-  "version": "0.2.1",
+  "version": "1.0.0-rc",
   "args": {
     "postgres_port": "5433",
     "django_port": "9090"

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,6 +1,6 @@
 # Orchfile Specification
 
-**Version**: 0.2.1  
+**Version**: 1.0.0-rc  
 **Target**: Local, ephemeral, development, and staging environments  
 **Not for**: Production deployments at scale
 
@@ -86,10 +86,12 @@ Service dependencies defined by `REQUIRES` and `AFTER` MUST form a directed acyc
 Asserts the Orchfile spec version the file targets. Optional, but if present it must be the first directive and appear before any `SERVICE`. A version that the parser does not support is a parse error.
 
 ```
-ORCH_VERSION 0.2.1
+ORCH_VERSION 1.0.0-rc
 ```
 
 When omitted, the file is assumed to target the parser's current spec version. In multi-file composition, any file may declare it.
+
+This is the version of the **Orchfile specification** (currently `1.0.0-rc`), which evolves independently of the `orch` library/CLI release version.
 
 #### ARG
 

--- a/examples/demo.orch
+++ b/examples/demo.orch
@@ -1,6 +1,6 @@
 # Example Orchfile for a typical Django + Postgres + Redis stack
 
-ORCH_VERSION 0.2.1
+ORCH_VERSION 1.0.0-rc
 
 ARG postgres_port=5433
 ARG postgres_memory=4G

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -121,7 +121,8 @@ percentage  ::= integer '%'
 number      ::= integer ( '.' digit+ )?
 integer     ::= digit+
 port        ::= digit+   /* 1-65535 */
-version_number ::= integer '.' integer '.' integer
+version_number ::= integer '.' integer '.' integer ( '-' prerelease )?
+prerelease  ::= ( letter | digit | '-' | '.' )+   /* e.g. rc, beta.1 */
 host_address ::= ( letter | digit | '.' | ':' )+   /* IPv4, IPv6, or hostname */
 
 letter      ::= [a-z]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,31 @@
-/// Output types for the orch parse pipeline.
+/// The `orch` library: parse Orchfiles into a resolved [`types::OrchFile`].
 ///
-/// These types represent the final, resolved Orchfile structure that
-/// `orch parse` serializes to JSON. Consumers (e.g. orchd) can depend
-/// on this crate and deserialize directly into these types.
+/// The full pipeline (`parser` -> `merge` -> `resolve`) is exposed so consumers
+/// can parse in-process rather than shelling out to the `orch` CLI. Deserialize
+/// CLI JSON output via [`types`], or call [`parse_files`] / the module functions
+/// directly on already-read file contents.
+pub mod error;
+pub mod merge;
+pub mod parser;
+pub mod resolve;
 pub mod types;
+
+use std::collections::HashMap;
+
+/// Parse, merge, and resolve a set of `(filename, contents)` inputs into a final
+/// [`types::OrchFile`].
+///
+/// Mirrors what `orch parse <files...>` does, but operates on already-read
+/// contents (no file I/O) and returns the structured value. Files are merged
+/// left-to-right using the overlay model. `overrides` take precedence over
+/// Orchfile `ARG` defaults.
+pub fn parse_files(
+    files: &[(String, String)],
+    overrides: &HashMap<String, String>,
+) -> Result<types::OrchFile, Vec<error::OrchError>> {
+    let refs: Vec<(&str, &str)> = files
+        .iter()
+        .map(|(name, content)| (name.as_str(), content.as_str()))
+        .collect();
+    parser::parse_files(&refs, overrides)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,3 @@
-mod error;
-mod merge;
-mod parser;
-mod resolve;
-
 use std::collections::HashMap;
 use std::env;
 use std::fs;
@@ -127,16 +122,11 @@ fn main() {
         }
     }
 
-    // Build refs for parse_files
-    let files: Vec<(&str, &str)> = file_contents
-        .iter()
-        .map(|(name, content)| (name.as_str(), content.as_str()))
-        .collect();
-
-    let result = if files.len() == 1 {
-        parser::parse(&files[0].1, &overrides)
+    let result = if file_contents.len() == 1 {
+        // Single file: omit the filename from error locations (just "line N").
+        orch::parser::parse(&file_contents[0].1, &overrides)
     } else {
-        parser::parse_files(&files, &overrides)
+        orch::parse_files(&file_contents, &overrides)
     };
 
     match command.as_str() {

--- a/src/merge.rs
+++ b/src/merge.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use orch::types::{ClearableMap, ClearableVec, RawOrchFile, RawService};
+use crate::types::{ClearableMap, ClearableVec, RawOrchFile, RawService};
 
 /// Merge multiple raw Orchfile representations left-to-right.
 ///

--- a/src/merge/tests.rs
+++ b/src/merge/tests.rs
@@ -1,7 +1,7 @@
 #![allow(non_snake_case)]
 
 use crate::merge::merge;
-use orch::types::{RawOrchFile, RawService, Source};
+use crate::types::{RawOrchFile, RawService, Source};
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::error::{OrchError, ParseError};
-use orch::types::*;
+use crate::types::*;
 
 /// Validate a service name per spec: lowercase alphanumeric + hyphens,
 /// starts with letter, max 63 chars.
@@ -165,13 +165,13 @@ pub fn parse_raw(input: &str, file_index: usize) -> Result<RawOrchFile, Vec<Orch
             orch_version_line = Some(line_num);
             match value {
                 Some(v) if !v.is_empty() => {
-                    if v != SPEC_VERSION {
+                    if v != ORCH_VERSION {
                         errors.push(
                             ParseError::new(
                                 line_num,
                                 format!(
                                     "unsupported Orchfile version '{}' (this parser supports {})",
-                                    v, SPEC_VERSION
+                                    v, ORCH_VERSION
                                 ),
                             )
                             .into(),

--- a/src/parser/tests.rs
+++ b/src/parser/tests.rs
@@ -806,7 +806,7 @@ ONESHOT true
 fn test_json_serialization() {
     let orch = parse_ok("SERVICE db\nFROM postgres:15\nPUBLISH 5432:5432\n");
     let json = serde_json::to_string_pretty(&orch).unwrap();
-    assert!(json.contains("\"version\": \"0.2.1\""));
+    assert!(json.contains("\"version\": \"1.0.0-rc\""));
     assert!(json.contains("\"name\": \"db\""));
     assert!(json.contains("\"mode\": \"container\""));
     assert!(json.contains("\"host\": 5432"));
@@ -1316,10 +1316,10 @@ SERVICE web
 fn test_orch_version__matching_is_accepted() {
     let input = format!(
         "ORCH_VERSION {}\nSERVICE db\nFROM postgres:15\n",
-        orch::types::SPEC_VERSION
+        crate::types::ORCH_VERSION
     );
     let orch = parse_ok(&input);
-    assert_eq!(orch.version, orch::types::SPEC_VERSION);
+    assert_eq!(orch.version, crate::types::ORCH_VERSION);
 }
 
 #[test]
@@ -1333,7 +1333,7 @@ fn test_orch_version__mismatch_is_rejected() {
 fn test_orch_version__must_precede_service() {
     let input = format!(
         "SERVICE db\nFROM img\nORCH_VERSION {}\n",
-        orch::types::SPEC_VERSION
+        crate::types::ORCH_VERSION
     );
     let errors = parse_err(&input);
     let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
@@ -1342,7 +1342,7 @@ fn test_orch_version__must_precede_service() {
 
 #[test]
 fn test_orch_version__duplicate_is_rejected() {
-    let v = orch::types::SPEC_VERSION;
+    let v = crate::types::ORCH_VERSION;
     let input = format!("ORCH_VERSION {v}\nORCH_VERSION {v}\nSERVICE db\nFROM img\n");
     let errors = parse_err(&input);
     let msgs: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
@@ -1359,7 +1359,7 @@ fn test_orch_version__requires_value() {
 #[test]
 fn test_orch_version__absent_defaults_to_spec_version() {
     let orch = parse_ok("SERVICE db\nFROM img\n");
-    assert_eq!(orch.version, orch::types::SPEC_VERSION);
+    assert_eq!(orch.version, crate::types::ORCH_VERSION);
 }
 
 // =========================================================================

--- a/src/resolve.rs
+++ b/src/resolve.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::error::{OrchError, ValidationError};
-use orch::types::*;
+use crate::types::*;
 
 /// Resolve a merged RawOrchFile into a final OrchFile.
 ///
@@ -45,7 +45,7 @@ pub fn resolve(
 
     // Step 7: C4 - DAG acyclicity
     let orch = OrchFile {
-        version: SPEC_VERSION.to_string(),
+        version: ORCH_VERSION.to_string(),
         args,
         services,
     };

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-/// The Orchfile spec version this parser implements (mirrors the package version).
-pub const SPEC_VERSION: &str = env!("CARGO_PKG_VERSION");
+/// The Orchfile **spec** version this parser implements.
+///
+/// This is the version of the Orchfile specification that the `ORCH_VERSION`
+/// directive declares and is validated against, independent of the `orch`
+/// library/CLI crate version in `Cargo.toml`. The spec and the tooling evolve
+/// on separate tracks.
+pub const ORCH_VERSION: &str = "1.0.0-rc";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -207,7 +212,7 @@ pub struct OrchFile {
 impl OrchFile {
     pub fn new() -> Self {
         OrchFile {
-            version: SPEC_VERSION.to_string(),
+            version: ORCH_VERSION.to_string(),
             args: HashMap::new(),
             services: Vec::new(),
         }

--- a/tests/api.rs
+++ b/tests/api.rs
@@ -1,0 +1,73 @@
+//! Integration tests exercising the public library API as an external consumer
+//! would (issue #4): parse in-process without shelling out to the `orch` CLI.
+
+use std::collections::HashMap;
+
+use orch::error::OrchError;
+use orch::types::{OrchFile, ServiceMode};
+
+#[test]
+fn parse_files_resolves_in_process() {
+    let files = vec![(
+        "Orchfile".to_string(),
+        "SERVICE db\nFROM postgres:15\nPUBLISH 5432:5432\n".to_string(),
+    )];
+    let orch: OrchFile = orch::parse_files(&files, &HashMap::new()).expect("should parse");
+
+    assert_eq!(orch.services.len(), 1);
+    assert_eq!(orch.services[0].name, "db");
+    assert_eq!(orch.services[0].mode, ServiceMode::Container);
+    assert_eq!(orch.version, orch::types::ORCH_VERSION);
+}
+
+#[test]
+fn parse_files_merges_overlays_left_to_right() {
+    let files = vec![
+        (
+            "base.orch".to_string(),
+            "SERVICE web\nFROM nginx\nPUBLISH 8080:80\n".to_string(),
+        ),
+        (
+            "overlay.orch".to_string(),
+            "SERVICE web\nPUBLISH 9090:80\n".to_string(),
+        ),
+    ];
+    let orch = orch::parse_files(&files, &HashMap::new()).expect("should parse");
+
+    assert_eq!(orch.services[0].publish.len(), 1);
+    assert_eq!(orch.services[0].publish[0].host, 9090);
+}
+
+#[test]
+fn parse_files_applies_overrides() {
+    let files = vec![(
+        "Orchfile".to_string(),
+        "ARG tag=15\nSERVICE db\nFROM postgres:${tag}\n".to_string(),
+    )];
+    let mut overrides = HashMap::new();
+    overrides.insert("tag".to_string(), "16".to_string());
+
+    let orch = orch::parse_files(&files, &overrides).expect("should parse");
+    assert_eq!(orch.services[0].image.as_deref(), Some("postgres:16"));
+}
+
+#[test]
+fn parse_files_surfaces_structured_errors() {
+    let files = vec![(
+        "bad.orch".to_string(),
+        "SERVICE bad\nFROM img\nRUN cmd\n".to_string(),
+    )];
+    let errs: Vec<OrchError> = orch::parse_files(&files, &HashMap::new()).expect_err("should fail");
+    assert!(errs.iter().any(|e| e.to_string().contains("C1")));
+}
+
+#[test]
+fn pipeline_modules_are_public_and_composable() {
+    // The lower-level pipeline (parser -> merge -> resolve) is reachable directly.
+    let raw = orch::parser::parse_raw("SERVICE x\nFROM img\n", 0).expect("raw parse");
+    assert_eq!(raw.services.len(), 1);
+
+    let merged = orch::merge::merge(vec![raw]);
+    let resolved = orch::resolve::resolve(merged, &HashMap::new(), &[]).expect("resolve");
+    assert_eq!(resolved.services[0].name, "x");
+}


### PR DESCRIPTION
## Summary
Releases **0.2.2**, with two coordinated changes.

### 1. Expose the parse pipeline as library API (closes #4)
- `src/lib.rs` now promotes `error`, `merge`, `parser`, `resolve` (plus existing `types`) to **public modules**, so the pipeline is reachable from the `orch` crate instead of being binary-only.
- Adds a one-call convenience:
  ```rust
  pub fn parse_files(
      files: &[(String, String)],
      overrides: &std::collections::HashMap<String, String>,
  ) -> Result<types::OrchFile, Vec<error::OrchError>>
  ```
- `src/main.rs` is now a thin CLI wrapper over the library; behavior is unchanged (single-file errors still omit the filename).
- Lets consumers like `orchd` parse **in-process** and drop the runtime dependency on the `orch` binary being on PATH.

### 2. Decouple spec version from tool version
- The Orchfile **spec** version (what `ORCH_VERSION` declares/validates against) is now an independent literal: **`1.0.0-rc`**.
- The **library/CLI** version stays ordinary semver in `Cargo.toml`, bumped to **`0.2.2`**.
- Renamed the constant `SPEC_VERSION` -> **`ORCH_VERSION`** (`orch::types::ORCH_VERSION`).
- Grammar's `version_number` now accepts a prerelease suffix (e.g. `-rc`).
- Per discussion, the JSON output keeps its `version` field, holding the spec version (`1.0.0-rc`).

## Tests
- New `tests/api.rs`: 5 integration tests compiled as an external crate, exercising `orch::parse_files`, overrides, error surfacing, and the composable `parser`/`merge`/`resolve` modules.
- Unit tests now run under `lib.rs`. **152 unit + 5 integration passing**, builds clean.

## Docs
Updated `SPEC.md` (spec version header + `ORCH_VERSION` note on spec/tool independence), `grammar.ebnf`, `README.md`, and `examples/demo.orch`.