### PR TITLE
Orchfile RFC 0001: node unit-spec directive set (grammar + SPEC)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -362,6 +362,13 @@ HEALTHCHECK redis-cli -h localhost ping
 - Starts with `http://` or `https://` → HTTP check (expect 2xx)
 - Otherwise → Execute command (expect exit code 0)
 
+**Semantics (RFC 0001)**: `HEALTHCHECK` is defined as exactly a `READINESS` probe.
+It gates dependents and traffic routing but never restarts the service, which is
+parity with the base behavior where `RESTART` fires only on process exit and a
+hung process is never replaced. For restart-on-unhealthy use `LIVENESS`
+explicitly; for hang/deadlock detection use `WATCHDOG`. See the Lifecycle &
+Health extensions below.
+
 #### READINESS_TIMEOUT
 
 How long to wait for HEALTHCHECK to pass during startup.
@@ -659,6 +666,184 @@ STDERR /var/log/myapp.err
 
 ---
 
+## RFC 0001 Extensions
+
+The directives below extend the **node unit spec** along three axes: time
+(lifecycle, health, states, conditions, change), space (node-local requirements,
+templated instances), and trust (sandbox, secrets, identity). Normative syntax is
+in [`grammar.ebnf`](grammar.ebnf).
+
+Out of scope, by design: cross-node placement, affinity, and redundancy
+(`PLACEMENT`/`AFFINITY`/`ANTI_AFFINITY`/`REDUNDANCY`) are a separate
+fleet-composition layer; and the assurance/compliance *vocabulary*
+(`sil`/`asil`/`dal`/`pci-dss`/...) lives in external profile documents, not in
+this grammar. The core interprets exactly one assurance key, the boolean `vital`.
+
+### Lifecycle & Health
+
+Splits the single `HEALTHCHECK` into distinct signals and adds a push channel,
+a watchdog, and a managed lifecycle.
+
+- `STARTUP <probe>`: gate that must pass before liveness/readiness are evaluated (slow boots).
+- `LIVENESS <probe>`: if it fails, the service is **restarted**.
+- `READINESS <probe>`: if it fails, dependents wait and traffic is withheld, but the service is **not** restarted.
+- `READY notify | poll`: push readiness over the orchd notify socket (`notify`) instead of being polled.
+- `WATCHDOG <duration>`: the service must emit a keep-alive within the window; a miss is treated as a hang and the service is restarted (catches deadlock/livelock).
+- `LIFECYCLE managed | simple`: `managed` exposes configure/activate/deactivate transitions (claim and configure hardware before acting); `simple` (default) is start/stop. On a managed service, a readiness failure deactivates (Active to Inactive), it does not restart; readiness loss is not a failure and never triggers `ON_FAILURE`.
+
+```
+STARTUP exec test -S /run/opcua.sock
+LIVENESS http://localhost:9100/livez
+READINESS http://localhost:9100/readyz
+READY notify
+WATCHDOG 20s
+LIFECYCLE managed
+```
+
+### Machine States
+
+File-global state set plus per-service membership. The active state determines
+which services run (the Adaptive AUTOSAR function-group model, generalized).
+
+- `MACHINE_STATES <name>...` (file-global): declares the machine's operational states.
+- `DEFAULT_STATE <name>` (file-global): state entered at boot.
+- `STATE <name>...`: the states in which a service is active (omitted = active in all states).
+- `GROUP <name>`: logical membership for bulk operations.
+- `SLICE <name>`: hierarchical resource-accounting group (cgroup subtree).
+
+```
+MACHINE_STATES running maintenance update
+DEFAULT_STATE running
+
+SERVICE collector
+STATE running
+SLICE data
+```
+
+Flat states only; concurrent function groups are a deferred non-goal. A future
+multi-group model must treat today's `MACHINE_STATES`/`STATE` as the single
+default group, so flat files remain valid.
+
+### Node-local Requirements
+
+Admission checks on every backend. Unmet requirements fail admission; pair with a
+`CONDITION` to make a requirement optional (then it skips instead of failing).
+
+- `ARCH <arch>`: required CPU architecture (e.g. `arm64`).
+- `DEVICE <path>`: required device node.
+- `REQUIRES_CAP <cap>[,<cap>...]`: required node capability (`gpu`, `npu`, `hugepages`, `sriov`, ...).
+
+```
+ARCH arm64
+DEVICE /dev/ttyS1
+REQUIRES_CAP hugepages,sriov
+```
+
+### Conditions, Windows & Failure
+
+`CONDITION`, `ASSERT`, and `WINDOW` take a **predicate** (`provider[:arg]`)
+resolved by an orchd provider; the provider set is a registry, not grammar.
+Standard providers include `network-online`, `network-trusted`, `time-synced`,
+`path-exists:<path>`, `power-state:<state>`, `arg:<name>`, `contact-pass`,
+`tariff:<name>`. Custom providers are reverse-DNS namespaced (`com.vendor.x`).
+
+- `CONDITION <predicate>`: start only if it holds, otherwise **skip** (not an error).
+- `ASSERT <predicate>`: like `CONDITION`, but unmet is a hard **failure**.
+- `WINDOW <predicate>`: active only while the (recurring) window is open.
+- `REQUIRES_HEALTHY <service>...`: wait until a dependency is *ready/healthy*, not merely started.
+- `ON_FAILURE <action>`: escalate on failure: `restart`, `state:<name>`, or `unit:<service>`.
+
+```
+CONDITION network-online
+CONDITION path-exists:/dev/gps
+ASSERT path-exists:/dev/irrig-interlock
+WINDOW tariff:offpeak
+REQUIRES_HEALTHY postgres
+ON_FAILURE state:safe-mode
+```
+
+### Security, Identity & Trust
+
+Least-privilege sandboxing, secret references (never values), attested identity,
+and audit. `SECRET` records a reference URI only; the secret value is never read,
+resolved, or emitted in `orch parse` output. This is the secure replacement for
+placing secrets in `ENV`, where the value would appear in plaintext.
+
+- `CAPABILITY drop:<set> add:<set>`: Linux capability bounding set.
+- `READONLY_ROOT <bool>`, `NO_NEW_PRIVILEGES <bool>`, `PRIVATE_TMP <bool>`: sandbox toggles.
+- `SECCOMP <profile>`: syscall filter (`default`, `strict`, or a named profile).
+- `EPHEMERAL <bool>`: state lives only in volatile memory; nothing survives power loss.
+- `ON_TAMPER zeroize | unit:<service>`: action on a tamper/capture signal.
+- `SECRET <NAME> from <reference>`: bind a secret by reference (`vault://`, `tpm://`, `file://`, or a reverse-DNS-namespaced scheme). Resolution happens at runtime in platform tooling. Merged by name; clearable via `CLEAR SECRET`.
+- `IDENTITY <spiffe-id> [scope=service|session]`: attested workload identity (SPIFFE SVID); `scope=session` mints per-transaction.
+- `AUDIT lifecycle | access`: mark events for the tamper-evident audit log.
+
+```
+CAPABILITY drop:ALL add:NET_BIND_SERVICE
+READONLY_ROOT true
+NO_NEW_PRIVILEGES true
+SECCOMP strict
+SECRET DB_PASSWORD from vault://canary/db
+IDENTITY spiffe://canary/web scope=session
+AUDIT lifecycle
+```
+
+### Change
+
+Health-gated, reversible change. On-node only; cross-node/fleet rollout is out of
+scope (fleet layer).
+
+- `UPDATE strategy=<ab|inplace> [rollback=on-health-fail] [signature=required]`: how a revision is applied; A/B with automatic rollback if the new revision fails its readiness gate.
+- `ROLLOUT strategy=<rolling|blue-green|canary> [max-unavailable=<n>] [gate=readiness]`: how an on-node rollout proceeds across a template's instances (or a single service's blue-green).
+
+```
+UPDATE strategy=ab rollback=on-health-fail signature=required
+ROLLOUT strategy=canary gate=readiness
+```
+
+### Observability
+
+- `METRICS <url> [format=prometheus]`: scrapeable metrics endpoint.
+- `TRACES <otlp-endpoint>`: trace export target (OpenTelemetry).
+- `LOG_FORMAT text | json`: structured log contract.
+
+### Lifecycle taxonomy
+
+- `SESSION daemon | oneshot | transactional`: `daemon` (default) is long-running; `oneshot` runs to completion; `transactional` is a stateful, possibly-paid session. `ONESHOT true` is exact sugar for `SESSION oneshot` and is retained for backward compatibility; new files should prefer `SESSION oneshot`.
+
+### Templated instances
+
+- `SERVICE <name>@`: declares a template service.
+- `INSTANCES <n>`: instantiate `name@1 .. name@n`.
+- `%i` / `%0Ni`: the instance index in directive values; `%i` is unpadded, `%0Ni` is zero-padded to width N. When composing an index into a numeric token (a port), use a fixed-width form so width does not shift past a power of ten.
+
+```
+SERVICE worker@
+INSTANCES 8
+ENV SHARD=%i
+READINESS http://localhost:96%02i/readyz
+```
+
+### Open assurance / label / profile facets
+
+Opaque, namespaced facets the core carries verbatim. Their vocabulary is
+interpreted by external **profile documents**, which expand them to concrete
+directives; that expansion is pinned in output. The one core-interpreted
+assurance key is the boolean `vital`, which marks a safety-critical path (it does
+not propagate across `REQUIRES`).
+
+- `ASSURANCE <k>=<v>...`: e.g. `vital=true sil=4 cert=en50128`. Only `vital` is core-interpreted; the rest is profile vocabulary.
+- `LABEL <k>=<v>...`: handling labels, e.g. `classification=secret`.
+- `PROFILE <name>[@<version>] [digest=<hash>]`: apply a named profile document.
+
+```
+ASSURANCE vital=true sil=4 cert=en50128
+LABEL classification=secret
+PROFILE pci-dss@1.2 digest=sha256:...
+```
+
+---
+
 ## File Composition (Overlay Model)
 
 Orchfile supports multi-file composition using a systemd drop-in inspired overlay model. A base Orchfile can be overlaid with environment-specific files (staging, CI, personal) that tune resources, ports, env vars, and dependencies without forking the entire file.
@@ -692,6 +877,7 @@ SERVICE web
 #### Keyed Lists: Merge by Key
 
 - **ENV**: Merged by variable name (overlay wins on conflict)
+- **SECRET**: Merged by secret name (overlay wins on conflict)
 - **PUBLISH**: Merged by container port (overlay replaces host address and port for same container port)
 - **VOLUME**: Merged by destination path (overlay replaces source for same destination)
 
@@ -742,6 +928,7 @@ The `CLEAR` directive resets a list-type field before applying overlay values. W
 ```
 CLEAR ENV
 CLEAR ENV_FILE
+CLEAR SECRET
 CLEAR PUBLISH
 CLEAR VOLUME
 CLEAR REQUIRES

--- a/grammar.ebnf
+++ b/grammar.ebnf
@@ -1,11 +1,17 @@
 orchfile    ::= ( line newline )*
-line        ::= blank | comment | version | arg | service_decl | directive
+line        ::= blank | comment | version | machine_states | default_state | arg | service_decl | directive
 blank       ::= ws*
 comment     ::= ws* '#' any*
 
 version     ::= 'ORCH_VERSION' ws version_number
+
+/* File-global machine states (RFC 0001); declared before any SERVICE */
+machine_states ::= 'MACHINE_STATES' ws state_name ( ws state_name )*
+default_state  ::= 'DEFAULT_STATE' ws state_name
+
 arg         ::= 'ARG' ws identifier '=' value
-service_decl ::= 'SERVICE' ws service_name
+service_decl ::= 'SERVICE' ws ( service_name | template_name )
+template_name ::= service_name '@'                  /* template; instantiate with INSTANCES */
 
 directive   ::= mode_directive
               | container_directive
@@ -19,7 +25,7 @@ clear_directive
 
 clearable_target
             ::= 'ENV' | 'ENV_FILE' | 'PUBLISH' | 'VOLUME'
-              | 'REQUIRES' | 'AFTER'
+              | 'REQUIRES' | 'AFTER' | 'SECRET'
 
 /* Execution mode - mutually exclusive per service */
 mode_directive
@@ -45,21 +51,44 @@ env_directive
               | 'ENV' ws env_key '=' value
               | 'ENV_FILE' ws path
 
+/* Common - machine-state membership (RFC 0001) */
+state_directive
+            ::= 'STATE' ws state_name ( ws state_name )*
+              | 'GROUP' ws identifier
+              | 'SLICE' ws identifier
+
 /* Common - dependencies */
 dependency_directive
             ::= 'REQUIRES' ws service_name ( ws service_name )*
+              | 'REQUIRES_HEALTHY' ws service_name ( ws service_name )*
               | 'AFTER' ws service_name ( ws service_name )*
 
-/* Common - health */
+/* Common - health & lifecycle (RFC 0001) */
 health_directive
-            ::= 'HEALTHCHECK' ws ( url | command_string )
+            ::= 'HEALTHCHECK' ws ( url | command_string )   /* retained; = READINESS only */
+              | 'STARTUP' ws probe
+              | 'LIVENESS' ws probe
+              | 'READINESS' ws probe
+              | 'READY' ws ( 'notify' | 'poll' )
+              | 'WATCHDOG' ws duration
+              | 'LIFECYCLE' ws ( 'managed' | 'simple' )
               | 'READINESS_TIMEOUT' ws duration
+
+/* Common - conditions, windows, failure escalation (RFC 0001).
+   CONDITION/ASSERT/WINDOW share one predicate-provider ABI; the provider set is
+   a resolver registry, NOT enumerated in this grammar. */
+predicate_directive
+            ::= 'CONDITION' ws predicate
+              | 'ASSERT' ws predicate
+              | 'WINDOW' ws predicate
+              | 'ON_FAILURE' ws fail_action
 
 /* Common - lifecycle */
 lifecycle_directive
             ::= 'ONESHOT' ws bool
               | 'DISABLED' ws bool
               | 'RECREATE' ws recreate_policy
+              | 'SESSION' ws session_model
 
 /* Common - restart */
 restart_directive
@@ -83,6 +112,49 @@ resource_directive
               | 'TASKS_MAX' ws integer
               | 'IO_WEIGHT' ws integer   /* 10-1000 */
 
+/* Common - node-local requirements (RFC 0001); admission checks */
+requirement_directive
+            ::= 'ARCH' ws identifier
+              | 'DEVICE' ws path
+              | 'REQUIRES_CAP' ws cap ( ',' cap )*
+
+/* Common - security, identity, trust (RFC 0001) */
+security_directive
+            ::= 'CAPABILITY' ws cap_spec
+              | 'READONLY_ROOT' ws bool
+              | 'NO_NEW_PRIVILEGES' ws bool
+              | 'PRIVATE_TMP' ws bool
+              | 'SECCOMP' ws identifier
+              | 'EPHEMERAL' ws bool
+              | 'ON_TAMPER' ws tamper_action
+              | 'SECRET' ws env_key ws 'from' ws secret_ref
+              | 'IDENTITY' ws spiffe_id ( ws 'scope=' identity_scope )?
+              | 'AUDIT' ws audit_kind
+
+/* Common - change (RFC 0001; on-node only; fleet rollout is RFC 0003) */
+change_directive
+            ::= 'UPDATE' ws kv ( ws kv )*
+              | 'ROLLOUT' ws kv ( ws kv )*
+
+/* Common - observability (RFC 0001) */
+observability_directive
+            ::= 'METRICS' ws url ( ws 'format=' identifier )?
+              | 'TRACES' ws url
+              | 'LOG_FORMAT' ws ( 'text' | 'json' )
+
+/* Common - open assurance / label / profile facets (RFC 0001).
+   Keys are opaque to the core; their vocabulary (sil, asil, dal, pci-dss, ...)
+   is defined by external profile documents (RFC 0002), NOT by this grammar.
+   The one core-interpreted assurance key is the boolean `vital`. */
+facet_directive
+            ::= 'ASSURANCE' ws kv ( ws kv )*
+              | 'LABEL' ws kv ( ws kv )*
+              | 'PROFILE' ws identifier ( '@' token )? ( ws 'digest=' token )?
+
+/* Common - templated instances (RFC 0001) */
+scale_directive
+            ::= 'INSTANCES' ws ( integer | var_ref )
+
 /* Common - logging */
 logging_directive
             ::= 'STDOUT' ws path
@@ -90,26 +162,57 @@ logging_directive
 
 common_directive
             ::= env_directive
+              | state_directive
               | dependency_directive
               | health_directive
+              | predicate_directive
               | lifecycle_directive
               | restart_directive
               | timeout_directive
               | resource_directive
+              | requirement_directive
+              | security_directive
+              | change_directive
+              | observability_directive
+              | facet_directive
+              | scale_directive
               | logging_directive
 
 /* Terminals */
 service_name ::= letter ( letter | digit | '-' )*   /* max 63 chars */
 identifier  ::= letter ( letter | digit | '_' )*
 env_key     ::= ( letter | '_' ) ( letter | digit | '_' )*
+state_name  ::= identifier
 
 image_ref   ::= ( any - newline )+
 command_string ::= ( any - newline )+
 path        ::= ( any - newline )+
 value       ::= ( any - newline )*
 url         ::= ( 'http://' | 'https://' ) ( any - newline )+
+token       ::= ( letter | digit | '-' | '_' | '.' | ':' | '/' )+
 
 var_ref     ::= '${' identifier '}'
+
+/* Probes and predicates (RFC 0001) */
+probe       ::= ( 'exec' ws command_string ) | url | command_string
+predicate   ::= provider ( ':' value )?            /* resolved by an orchd provider; not enumerated */
+provider    ::= identifier ( '.' identifier )*     /* bare = standard registry; dotted = reverse-DNS plugin */
+fail_action ::= 'restart' | 'state:' state_name | 'unit:' service_name
+tamper_action ::= 'zeroize' | 'unit:' service_name
+session_model ::= 'daemon' | 'oneshot' | 'transactional'
+identity_scope ::= 'service' | 'session'
+audit_kind  ::= 'lifecycle' | 'access'
+
+/* Security / facet terminals (RFC 0001) */
+cap         ::= ( letter | digit | '_' )+          /* e.g. gpu, npu, hugepages, sriov */
+cap_spec    ::= ( 'drop:' capset )? ( ws? 'add:' capset )?
+capset      ::= 'ALL' | cap_name ( ',' cap_name )*
+cap_name    ::= ( upper | '_' )+                   /* e.g. NET_BIND_SERVICE */
+kv          ::= identifier '=' token
+secret_ref  ::= scheme '://' ( any - newline )+    /* reference only; secret value never read (opaque) */
+scheme      ::= letter ( letter | digit | '+' | '-' | '.' )*   /* bare scheme reserved; custom = reverse-DNS */
+spiffe_id   ::= 'spiffe://' ( any - newline )+
+index_ref   ::= '%' ( '0' digit+ )? 'i'            /* instance index inside a value: %i, or %0Ni (padded) */
 
 bool        ::= 'true' | 'false'
 restart_policy ::= 'no' | 'always' | 'on-failure'
@@ -126,6 +229,7 @@ prerelease  ::= ( letter | digit | '-' | '.' )+   /* e.g. rc, beta.1 */
 host_address ::= ( letter | digit | '.' | ':' )+   /* IPv4, IPv6, or hostname */
 
 letter      ::= [a-z]
+upper       ::= [A-Z]
 digit       ::= [0-9]
 ws          ::= [ #x9]+
 newline     ::= #xA


### PR DESCRIPTION
## What

Adds the **RFC 0001** directive set to the Orchfile spec: a node-scoped extension
across three axes, **time** (lifecycle, health, states, conditions, change),
**space** (node-local requirements, templated instances), and **trust** (sandbox,
secrets, identity).

This is a **grammar + spec diff only**. The hand-rolled parser is deliberately
untouched; `grammar.ebnf` is the normative artifact and is self-sufficient for
parser implementation in a follow-up.

## Directives added (grammar.ebnf + SPEC.md)

- **Lifecycle & health:** `STARTUP`, `LIVENESS`, `READINESS`, `READY notify|poll`, `WATCHDOG`, `LIFECYCLE managed|simple`
- **Machine states:** file-global `MACHINE_STATES` / `DEFAULT_STATE`; per-service `STATE`, `GROUP`, `SLICE`
- **Node-local requirements:** `ARCH`, `DEVICE`, `REQUIRES_CAP` (admission checks)
- **Conditions / windows / failure:** `CONDITION`, `ASSERT`, `WINDOW` (one predicate-provider ABI), `REQUIRES_HEALTHY`, `ON_FAILURE`
- **Security & trust:** `CAPABILITY`, `READONLY_ROOT`, `NO_NEW_PRIVILEGES`, `PRIVATE_TMP`, `SECCOMP`, `EPHEMERAL`, `ON_TAMPER`, `SECRET <NAME> from <ref>`, `IDENTITY [scope=]`, `AUDIT`
- **Change:** `UPDATE`, `ROLLOUT` (on-node)
- **Observability:** `METRICS`, `TRACES`, `LOG_FORMAT`
- **Lifecycle taxonomy:** `SESSION daemon|oneshot|transactional`
- **Templated instances:** `SERVICE name@`, `INSTANCES`, `%i` / `%0Ni`
- **Open facets:** `ASSURANCE`, `LABEL`, `PROFILE`

## Correctness fix

`HEALTHCHECK` is now defined as exactly `READINESS` (gates dependents/traffic, no
restart). This is behavioral parity with current files: today `RESTART` fires only
on process exit, so a `HEALTHCHECK` was never a restart trigger. Restart-on-unhealthy
is now an explicit `LIVENESS`; hang detection is `WATCHDOG`.

## Scope boundaries (deliberate)

- **Out of the unit grammar:** cross-node `PLACEMENT`/`AFFINITY`/`ANTI_AFFINITY`/`REDUNDANCY`. Those are a separate fleet-composition layer.
- **Out of the grammar:** assurance/compliance *vocabulary* (`sil`/`asil`/`dal`/`pci-dss`/...). It lives in external profile documents. The core interprets exactly one assurance key, the boolean `vital`.
- `SECRET` records a **reference URI only**; the secret value is never read, resolved, or emitted (closes the plaintext-secret-in-`ENV` hole).

## Notes for reviewers

- Versioning: additive to the unreleased `1.0.0-rc` baseline; no version-train. `ORCH_VERSION` const unchanged.
- Parser: not implemented here (intentional). The grammar is the contract.
- `docs/grammar.pdf` / `docs/grammar.tex` are generated from `grammar.ebnf` and will need regeneration; not done in this PR.